### PR TITLE
Use analytics_debug.js if debug enabled.

### DIFF
--- a/src/utils/loadGA.js
+++ b/src/utils/loadGA.js
@@ -1,4 +1,11 @@
 export default function (options) {
+  var gaAddress = 'https://www.google-analytics.com/analytics.js'
+  if (options && options.gaAddress) {
+    gaAddress = options.gaAddress;
+  } else if (options && options.debug) {
+    gaAddress = 'https://www.google-analytics.com/analytics_debug.js'
+  }
+  
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/
   /* eslint-disable */
   (function (i, s, o, g, r, a, m) {
@@ -11,6 +18,6 @@ export default function (options) {
     a.async = 1;
     a.src = g;
     m.parentNode.insertBefore(a, m);
-})(window, document, 'script', options && options.gaAddress ? options.gaAddress : 'https://www.google-analytics.com/analytics.js', 'ga');
+})(window, document, 'script', gaAddress, 'ga');
   /* eslint-enable */
 }


### PR DESCRIPTION
There's a [debug version of the analytics.js](https://developers.google.com/analytics/devguides/collection/analyticsjs/debugging) that can also be used to add more debug information.


Also, rather than a complex ternary switched to an if-statement.